### PR TITLE
SOAP → SAVON

### DIFF
--- a/traductions.json
+++ b/traductions.json
@@ -126,6 +126,7 @@
         {"anglais": "Slash", "français": "Barre oblique", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Smart grids", "français": "Grilles malignes", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Smiley", "français": "Émoticône", "genre": "f", "classe": "groupe nominal", "pluriel": false},
+        {"anglais": "SOAP (Simple Object Access Protocol)", "français": "SAVON (Simple Accès Vers Objets Nuageux)", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "SoC (System-on-Chip)", "français": "Puce-système", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Spam", "français": "Polluriel, pourriel", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Spammer", "français": "Arroseur publicitaire", "genre": "m", "classe": "groupe nominal", "pluriel": false},


### PR DESCRIPTION
Bonjour 

SOAP (Simple Object Access Protocol) https://fr.wikipedia.org/wiki/SOAP
SAVON (Simple Accès Vers Objets Nuageux)

Ici, la notion de *nuageux* a deux significations complémentaires: 
- des objets distants, dans le nuage.
- la mousse du savon forme un petit nuage.