### PR TITLE
Compilogenese

### DIFF
--- a/traductions.json
+++ b/traductions.json
@@ -17,6 +17,7 @@
         {"anglais": "Benchmark", "français": "Banc d’essai", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Big data", "français": "Mégadonnées", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Big-endian", "français": "Grand boutien", "genre": "m", "classe": "adjectif", "pluriel": false},
+        {"anglais": "Binding", "français": "Reliage", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Bloatware", "français": "Boufficiel", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Blockchain", "français": "Chaîne de blocs", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Boot", "français": "Amorçage", "genre": "m", "classe": "groupe nominal", "pluriel": false},

--- a/traductions.json
+++ b/traductions.json
@@ -21,6 +21,8 @@
         {"anglais": "Bloatware", "français": "Boufficiel", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Blockchain", "français": "Chaîne de blocs", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Boot", "français": "Amorçage", "genre": "m", "classe": "groupe nominal", "pluriel": false},
+        {"anglais": "Bootstrapping (compiler)", "français": "Compilogénèse", "genre": "f", "classe": "groupe nominal", "pluriel": false},
+        {"anglais": "Bootstrapping (OS)", "français": "Autoamorçage", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Browser", "français": "Navigateur", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Buffer", "français": "Tampon", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Buffer overflow", "français": "Dépassement de tampon", "genre": "m", "classe": "groupe nominal", "pluriel": false},


### PR DESCRIPTION
Alors sur celui-ci j'ai plusieurs propositions. Déjà on parle surtout de bootstrap mais de façon indistincte pour le verbe ou le nom donc je ne sais pas s'il faut faire une entrée pour bootstrapping ou pour bootstrap.

Ensuite, dans le domaine restreint de la compilation, compilogénèse est très beau. Le problème c'est qu'il est dédié, donc, à un compilateur qui s'auto-compile.

Dans les autres propositions il y avait donc autocompilation (moins pédant mais moins drôle). (j'ai construit compilogénèse par rapport à parthénogénèse. 

Sinon il y a aussi "autoamorçage" qui a le mérite d'être plus générique.