### PR TITLE
Ajout de la licence publique bitoduc dans la version 1

### DIFF
--- a/LICENSE PUBLIQUE BITODUC.md
+++ b/LICENSE PUBLIQUE BITODUC.md
@@ -1,0 +1,30 @@
+LICENSE PUBLIQUE BITODUC 1.0
+
+Le logiciel bitoduc.fr, et ses données associées ("Logiciel") sont publiés
+dans le domaine public.
+
+N'importe qui est libre de les copier, de les modifier, de les publier, de
+l’utiliser, de les compiler, et de les vendre, ou bien de les distribuer
+(si tant est que quelqu’un en veuille), que ce soit sous forme de code
+source ou de binaire compilé ; pour tout usage, commercial ou non, et par
+n’importe quel moyen.
+
+Dans les juridictions territoriales qui reconnaissent les lois du droit
+d'auteur, l’auteur-e ou les auteur-e-s du Logiciel renoncent à tout
+intérêt sur le Logiciel pour l'offrir au domaine public.  Nous faisons
+cette offre pour le bien public en général et au détriment de nos
+héritier-e-s et successeur-e-s. Nous voulons que cette offre soit un acte
+manifeste de renoncement perpétuel de tout droit présent et futur sur ce
+Logiciel tel que les définissent les lois sur le droit d'auteur. Ainsi
+sont les bails.
+
+CE LOGICIEL EST PROPOSÉ « TEL QUEL », SANS GARANTIE D’AUCUNE SORTE,
+EXPLICITE OU IMPLICITE, EN INCLUANT MAIS NE SE LIMITANT PAS AUX GARANTIES
+DE QUALITÉ MARCHANDE, D’ADÉQUATION À UN USAGE PARTICULIER ET DE
+NON-VIOLATION DES DROITS D’AUTEUR.  EN AUCUN CAS LES AUTEUR-E-S NE
+SAURAIENT ÊTRE TENU-E-S RESPONSABLES POUR AUCUNE DÉCLARATION, DOMMAGES OU
+AUTRE RESPONSABILITÉ, QUE CE SOIT PAR UNE ACTION CONTRACTUELLE, UN DÉFAUT,
+OU AUTRE DÉSAGRÉMENT, ENTRAINÉ PAR, OU EN CONNEXION AVEC LE LOGICIEL OU
+SON USAGE OU TOUTE INTERACTION AVEC LE LOGICIEL SUSCITÉ.
+
+Pour plus d’information, veuillez vous référer à <http://bitoduc.fr/>


### PR DESCRIPTION
L'ajout de cette licence résout le bogue #78 et #161 en permettant à de tierces parties de réutiliser les données de bitoduc.fr pour les diffuser plus avant. Ce qui est plutôt glop.