### PR TITLE
Ajout de la traduction de Pod

### DIFF
--- a/traductions.json
+++ b/traductions.json
@@ -116,6 +116,7 @@
         {"anglais": "Pipeline", "français": "Bitoduc", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Placeholder", "français": "Marque substitutive", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Plugin", "français": "Greffon", "genre": "m", "classe": "groupe nominal", "pluriel": false},
+        {"anglais": "Pod", "français": "Gousse", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Podcasting", "français": "Balladodiffusion", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Polling", "français": "Attente active", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Polyfill", "français": "Prothèse d'émulation", "genre": "f", "classe": "groupe nominal", "pluriel": false},


### PR DESCRIPTION
Je pense que vu la popularité grandissante de Kubernetes, il est nécessaire de proposer une traduction pour `pod`, dont `gousse` me semble être le candidat parfait.