### PR TITLE
Ajustement de la traduction de crypto-currency

### DIFF
--- a/traductions.json
+++ b/traductions.json
@@ -48,7 +48,7 @@
         {"anglais": "Cookie", "français": "Témoin de connexion", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Core dump", "français": "Vidage de mémoire", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Crawler", "français": "Butineur", "genre": "m", "classe": "groupe nominal", "pluriel": false},
-        {"anglais": "Crypto-currency", "français": "Crypto-actif", "genre": "m", "classe": "groupe nominal", "pluriel": false},
+        {"anglais": "Crypto-currency", "français": "Crypto-monnaie", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Dangling pointer", "français": "Pointeur fou", "genre": "m", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "Database", "français": "Base de données", "genre": "f", "classe": "groupe nominal", "pluriel": false},
         {"anglais": "DDoS (Distributed Denial of Service)", "français": "DSD (Déni de Service Distribué)", "genre": "m", "classe": "groupe nominal", "pluriel": false},


### PR DESCRIPTION
Pour faire suite à la discussion ayant lieu dans #182, il me semble plus pertinent d'utiliser le terme de `crypto-monnaie` pour traduire `crypto-currency`. Actif se traduit en `asset`, ce qui n'a rien à voir avec `currency`, la monnaie.

Pourquoi monnaie plutôt que devise ? Parce que dans sa définition, devise signifie "_tout actif financier liquide libellé en monnaie étrangère_" [[définition](http://www.cnrtl.fr/definition/devise)]. Le caractère étranger de la crypto-monnaie ne me semble pas forcément adéquat.