### PR TITLE
Proposition de la traduction "Pot-pourriciel" pour "Mash-up"

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -131,6 +131,8 @@
     {"anglais": "Malware", "français": "Maliciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Man-in-the-middle attack (MITM)", "français": "Attaque de l’homme du milieu (HDM)", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Mapping", "français": "Correspondance", "genre": "f", "classe": "nom propre"},
+    {"anglais": "Mash-up", "français": "Pot-pourriciel", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Mash-up", "français": "Pot-pourriciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Middleware", "français": "Intersticiel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Monkey-in-the-middle attack", "français": "Attaque du singe intercepteur", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Mouse jacking", "français": "Vol à la souris", "genre": "m", "classe": "groupe nominal"},

--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -132,7 +132,6 @@
     {"anglais": "Man-in-the-middle attack (MITM)", "français": "Attaque de l’homme du milieu (HDM)", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Mapping", "français": "Correspondance", "genre": "f", "classe": "nom propre"},
     {"anglais": "Mash-up", "français": "Pot-pourriciel", "genre": "m", "classe": "groupe nominal"},
-    {"anglais": "Mash-up", "français": "Pot-pourriciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Middleware", "français": "Intersticiel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Monkey-in-the-middle attack", "français": "Attaque du singe intercepteur", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Mouse jacking", "français": "Vol à la souris", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Un mash-up étant la collecte de résultats depuis un ensemble de services pour en tirer le meilleur ensemble, l'idée de "pot-pourri" permet de couvrir cette notion.