### PR TITLE
Ajout de la traduction de Bit

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -18,6 +18,7 @@
     {"anglais": "Big data", "français": "Mégadonnées", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Big-endian", "français": "Grand boutien", "genre": "m", "classe": "adjectif"},
     {"anglais": "Binding", "français": "Reliage", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Bit (Binary digit)", "français": "Chibi", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Bloatware", "français": "Boufficiel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Blockchain", "français": "DEEP (Dispositif d'Enregistrement Électronique partagé)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Boot", "français": "Amorçage", "genre": "m", "classe": "groupe nominal"},

--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -18,7 +18,7 @@
     {"anglais": "Big data", "français": "Mégadonnées", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Big-endian", "français": "Grand boutien", "genre": "m", "classe": "adjectif"},
     {"anglais": "Binding", "français": "Reliage", "genre": "m", "classe": "groupe nominal"},
-    {"anglais": "Bit (Binary digit)", "français": "Chibi", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Bit (Binary digit)", "français": "Chibi (Chiffre Binaire)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Bloatware", "français": "Boufficiel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Blockchain", "français": "DEEP (Dispositif d'Enregistrement Électronique partagé)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Boot", "français": "Amorçage", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
J'ai le regret de vous annoncer que 'bit' est malheureusement un mot anglais. C'est une contraction de 'binary' et de 'digit'. Je vous propose une traduction plutôt littérale: 'chibi'. Cette contraction de 'chiffre' et 'binaire' est, je trouve parfaitement adaptée pour traduire l'idée de petite quantité d'information.