### PR TITLE
Cyber-monnaire pour être en accord avec Cybersou

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -59,7 +59,7 @@
     {"anglais": "Cookie", "français": "Témoin de connexion", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Core dump", "français": "Vidage de mémoire", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Crawler", "français": "Butineur", "genre": "m", "classe": "groupe nominal"},
-    {"anglais": "Crypto-currency", "français": "Crypto-monnaie", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Crypto-currency", "français": "Cyber-monnaie", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Cryptocoin", "français": "Cybersou", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Cryptography", "français": "Chiffrement", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Cryptoparty", "français": "Chiffrofête", "genre": "f", "classe": "groupe nominal"},


### PR DESCRIPTION
Bonjour,

Je vous propose de corriger la traduction `Crypto-monnaie` en `Cyber-monnaie` afin d'obtenir une meilleure cohésion avec la traduction `Cybersou` déjà validée et une meilleure adéquation avec les recommandations de l'Académie Française.