### PR TITLE
Ajout de la traduction Billevesée

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -31,6 +31,7 @@
     {"anglais": "Buffer", "français": "Tampon", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Buffer overflow", "français": "Dépassement de tampon", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Bug", "français": "Bogue", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Bullshit", "français": "Billevesée", "genre": "f", "classe": "nom commun"},
     {"anglais": "Bundle", "français": "Colis", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Buzz", "français": "Ramdam", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Buzzword", "français": "Mot à la mode", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Cet atome de code se voit pour objectif sacral de rajouter une ligne de
traduction pour rendre cette base de donnée conforme au standard
populaire. En effet, grande nouvelle pour les amateurs de langue
française, une nouvelle traduction a été populairement popularisé par le
vidéaste professionnel et néanmoins gouleyant 'Monsieur Bidouille' dans
sa vidéo youtube visible au lien ci dessous :
https://www.youtube.com/watch?v=QOIGDL8IOOA