### PR TITLE
Ajout de "git <-> con"

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -103,6 +103,7 @@
     {"anglais": "Fuzzing", "français": "Frelatage en masse", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "GC (Garbage Collector)", "français": "Ramasse-miettes, glaneur de cellule", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "GDPR (General Data Protection Regulation)", "français": "RGPD (Règlement Général sur la Protection des Données)", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "git (pejoratively-named distributed version-control system, optionally meaning 'global information tracker')", "français": "con (système de contrôle de versions avec un nom péjoratif, optionnellement signifiant 'CONtrôleur de versions')", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Glue code", "français": "Code ciment", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "God object", "français": "Objet omniscient", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Hacked", "français": "Intrusé", "genre": "m", "classe": "adjectif"},


### PR DESCRIPTION
Linus Torvalds a lui-même dit (https://git.wiki.kernel.org/index.php/GitFaq#Why_the_.27Git.27_name.3F) :

> Why the 'Git' name?

> Quoting Linus: "I'm an egotistical bastard, and I name all my projects after myself. First 'Linux', now 'Git'".

> ('git' is British slang for "pig headed, think they are always correct, argumentative"). 

> Alternatively, in Linus' own words as the inventor of Git: "git" can mean anything, depending on your mood: 

> "Global information tracker": you're in a good mood, and it actually works for you. Angels sing and light suddenly fills the room. 

Donc, `con` pour *contrôle de versions* respecte les mêmes principes que l'original, tout en gardant le même nombre de lettres.