### PR TITLE
Ajout de Contaminanalyse pour "Tainting analysis"

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -208,6 +208,7 @@
     {"anglais": "Switch", "français": "Commutateur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Tablet", "français": "Planchette (tactile, digitale)", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Tag", "français": "Étiquette", "genre": "f", "classe": "groupe nominal"},
+    {"anglais": "Tainting analysis", "français": "Contaminanalyse", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Thread", "français": "Fil d'exécution", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Thread pool", "français": "Réserve de fils d'exécution", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Thumbnail", "français": "Imagette", "genre": "f", "classe": "groupe nominal"},


### PR DESCRIPTION
Je cherchais depuis un moment une traduction pour "Tainting analysis". Quelqu'un, sur Framasphere, a mentionné bitoduc.fr. Je me suis dit que j'allais enfin trouver mon bonheur, mais "Tainting analysis" n'était pas là. J'ai donc utilisé mon propre cerveau, ce que je fais rarement.