### PR TITLE
FPGA -> MPRI (Matrice de Portes logique, Reconfigurable In-situ)

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -95,7 +95,7 @@
     {"anglais": "Flame", "français": "Propos incendiaire", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Flood", "français": "Matraquage", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Fork", "français": "Scission", "genre": "f", "classe": "groupe nominal"},
-    {"anglais": "FPGA (Field-Programmable Gate Array)", "français": "CIPP (Circuit Intégré Prédiffusé Programmable)", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "FPGA (Field-Programmable Gate Array)", "français": "MPRI (Matrice de Portes logique, Reconfigurable In-situ)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Framework", "français": "Cadriciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Freeware", "français": "Gratuiciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Front office", "français": "Guichet", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Cette traduction est inexacte, je pense. Les FPGA n'ont jamais été des circuits prédiffusés. Ce sont des circuits intégrés complets auxquels il ne manque aucune couche et qu'on peut utiliser immédiatement sans en terminer la fabrication.

Je propose donc plutôt "_Matrice de Portes logique, Reconfigurable In-situ (MPRI)_". Le choix a été fait de conserver le sens originel de FPGA plutôt que son sens actuel dont la traduction serait plutôt quelque chose comme "_Circuit Intégré Reconfigurable (CIR)_" ou "_Circuit Intégré Flexible Reconfigurable (CIFR)_".