### PR TITLE
cryptography

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -61,7 +61,7 @@
     {"anglais": "Crawler", "français": "Butineur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Crypto-currency", "français": "Crypto-monnaie", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Cryptocoin", "français": "Cybersou", "genre": "m", "classe": "groupe nominal"},
-    {"anglais": "Cryptography", "français": "Chiffrement", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Cryptography", "français": "Cryptographie", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Cryptoparty", "français": "Chiffrofête", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Cybernaut", "français": "Internaute", "genre": "n", "classe": "groupe nominal"},
     {"anglais": "Cybersquatting", "français": "Accaparement de nom de domaine", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Je ne sais pas pourquoi "_chiffrement_" a initialement été préféré à "_cryptographie_" mais c'est plutôt inexact. La cryptographie est plus vaste et recouvre d'autres domaines que le seul chiffrement (intégrité, authentification, non-répudiation, etc.)

On pourrait faire la même analyse avec "_Cryptoparty_" / "_Chiffrofête_" et tenter "_Cryptofête_" mais je suis plus réservé parce que c'est moins drôle et, surtout, pourrait avoir le sens de fête cachée ou secrète, comme dans cryptocommuniste.