### PR TITLE
Socket: donnécteur

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -196,6 +196,7 @@
     {"anglais": "Sniffer", "français": "Renifleur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "SOAP (Simple Object Access Protocol)", "français": "SAVON (Simple Accès Vers Objets Nuageux)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "SoC (System-on-Chip)", "français": "Puce-système", "genre": "f", "classe": "groupe nominal"},
+    {"anglais": "Socket", "français": "Donnécteur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Software", "français": "Logiciel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Solver", "français": "Solveur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Spam", "français": "Polluriel, pourriel", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Il manque vraiment une traduction à "_socket_". "_Donnécteur_" est une contraction de donnée et connecteur. Je ne suis pas très satisfait du "_é_" accent aigu avant un "_c_" mais "_donnecteur_" est à peu près incompréhensible et "_donnéecteur_" me semble encore pire que "_donnécteur_". Des idées ?