### PR TITLE
Dangling pointer -> Pointeur sautillant

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -65,7 +65,7 @@
     {"anglais": "Cryptoparty", "français": "Chiffrofête", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Cybernaut", "français": "Internaute", "genre": "n", "classe": "groupe nominal"},
     {"anglais": "Cybersquatting", "français": "Accaparement de nom de domaine", "genre": "m", "classe": "groupe nominal"},
-    {"anglais": "Dangling pointer", "français": "Pointeur fou", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Dangling pointer", "français": "Pointeur sautillant", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Dark net", "français": "Internet clandestin", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Data scientist", "français": "Expert·e en mégadonnées", "genre": "n", "classe": "groupe nominal"},
     {"anglais": "Database", "français": "Base de données", "genre": "f", "classe": "groupe nominal"},


### PR DESCRIPTION
Je propose de changer la traduction de "Dangling pointeur" en "Pointeur sautillant", en référence à la traduction littérale [donnée par Wikipédia FR](https://fr.wikipedia.org/wiki/Dangling_pointer), qui me semble plus juste pour deux (±1) raisons :

1. Elle se rapproche de la définition technique qui consiste fondamentalement en un pointeur dont la valeur adressée pourrait potentiellement être modifiée voire changer de place en mémoire, d'où la caractéristique "sautillante" de celle-ci et par extension, du pointeur.
2. Elle ne fait pas référence au concept de fou, souvent psychophobe, tout en gardant une sémantique proche sur le côté improbable et imprévisible d'un tel pointeur
3. Il serait alors possible d'en faire un parallèle avec un lapin, qui sautille aussi. Et c'est mignon les lapins.

La page Wikipédia FR mentionnée propose également "Pointeur pendouillant" comme traduction littérale, mais bien qu'aussi rigolote, elle me semble moins claire et explicite sur les propriétés d'un tel pointeur.