### PR TITLE
Ajout de "Union-Find" (Unit-trouve)

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -228,6 +228,7 @@
     {"anglais": "Typosquatting", "français": "Faute de frappe opportuniste", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Underscore", "français": "Sous-tiret", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Upload", "français": "Téléversement", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Union-find", "français": "Unit-trouve", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "URL", "français": "Adresse réticulaire", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "USB key", "français": "Mémorette", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "User Interface (UI)", "français": "Interface Homme-Machine (IHM)", "genre": "f", "classe": "groupe nominal"},


### PR DESCRIPTION
Union-find <https://fr.wikipedia.org/wiki/Union-find> est une structure de donnée qui implémente efficacement deux opérations, "unit" (union) et "trouve" (find).

Usages:
- l'algorithme unit-trouve
- on résoud ce problème en utilisant unit-trouve
- mon contexte contient un unit-trouve pour les égalités entres types

(Selon les usages "unit-trouve" désigné l'algorithme, la structure de donnée, ou une instance de la structure (comme on dit "un tableau", "une liste", etc.)