### PR TITLE
"Electronic form" <=> "Formuel"

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -84,6 +84,7 @@
     {"anglais": "Downloadable Content (DLC)", "français": "Contenu Téléchargeable Additionnel (CTA)", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "DRY (Don't Repeat Yourself)", "français": "NTRP (Ne Te Répète Pas)", "classe": "proposition"},
     {"anglais": "E-mail", "français": "Courriel", "genre": "m", "classe": "groupe nominal"},
+    {"anglais": "Electronic form", "français": "Formuel", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Empowerment", "français": "Empouvoirement", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Encrypted", "français": "Chiffré", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Endianness", "français": "Boutisme", "genre": "m", "classe": "groupe nominal"},


### PR DESCRIPTION
Cette super traduction digne de bitoduc vous est proposée par la [DGFiP](https://www.qwant.com/?l=fr&sr=fr&r=FR&q=%22formuel%22+site%3Aimpots.gouv.fr&t=web)