### PR TITLE
Home row → Rangée de repos

### DIFF
--- a/liste_de_traductions.json
+++ b/liste_de_traductions.json
@@ -117,7 +117,7 @@
     {"anglais": "Hash table", "français": "Tableau à adressage dispersé", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Hashtag", "français": "Mot-croisillon", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Heap spray", "français": "Pulvérisation du tas", "genre": "f", "classe": "groupe nominal"},
-    {"anglais": "Home row", "français": "Touche de repos", "genre": "f", "classe": "groupe nominal"},
+    {"anglais": "Home row", "français": "Rangée de repos", "genre": "f", "classe": "groupe nominal"},
     {"anglais": "Hub", "français": "Concentrateur", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Hyperlink", "français": "Hyperlien", "genre": "m", "classe": "groupe nominal"},
     {"anglais": "Infobox", "français": "Infoboîte", "genre": "n", "classe": "groupe nominal"},


### PR DESCRIPTION
La “Home row” fait référence à la rangée de touches du clavier sur laquelle reposent les doigts. Il est donc inexact de traduire cela par une simple « Touche de repos ». À la limite on pourrait parler de touches au pluriel, mais à titre personnel je trouve le mot « rangée » plus fidèle au terme anglophone.